### PR TITLE
* Fixes problem with IE8 throwing exception in commonAncestor.

### DIFF
--- a/jquery.scrollIntoView.js
+++ b/jquery.scrollIntoView.js
@@ -116,7 +116,7 @@
             minlen = Math.min(minlen, curparents.length);
         });
 
-        for (var i in parents) {
+        for (var i=0; i<parents.length; i++)
             parents[i] = parents[i].slice(parents[i].length - minlen);
         }
 


### PR DESCRIPTION
Complementary fix to #3.
Previous 

```
 for( var i in parents ) 
    parents[i] = parents[i].slice(parents[i].length - minlen);
 }
```

Does not iterate through elements but array methods aswell.
