### PR TITLE
Option to only scroll up and option to set an offset to the final position

### DIFF
--- a/jquery.scrollIntoView.js
+++ b/jquery.scrollIntoView.js
@@ -52,7 +52,7 @@
             // it wiggles?
             (pEl.scrollTop != ((pEl.scrollTop += 1) == null || pEl.scrollTop) && (pEl.scrollTop -= 1) != null) ||
             (pEl.scrollTop != ((pEl.scrollTop -= 1) == null || pEl.scrollTop) && (pEl.scrollTop += 1) != null)) {
-                if (elY <= pY) scrollTo(pEl, elY); // scroll up
+                if ((opts.alignWithTop && (elY + elH) > (pY + pH)) || elY <= pY) scrollTo(pEl, elY); // scroll up
                 else if ((elY + elH) > (pY + pH)) scrollTo(pEl, elY + elH - pH); // scroll down
                 else scrollTo(pEl, undefined) // no scroll
                 return;
@@ -66,9 +66,9 @@
             if (scrollTo === undefined) {
                 if ($.isFunction(opts.complete)) opts.complete.call(el);
             } else if (opts.smooth) {
-                $(el).stop().animate({ scrollTop: scrollTo }, opts);
+                $(el).stop().animate({ scrollTop: scrollTo + opts.offset }, opts);
             } else {
-                el.scrollTop = scrollTo;
+                el.scrollTop = scrollTo + opts.offset;
                 if ($.isFunction(opts.complete)) opts.complete.call(el);
             }
         }
@@ -83,7 +83,9 @@
         //       otherwise jQuery will default to use 'swing'
         complete: $.noop(),
         step: null,
-        specialEasing: {} // cannot be null in jQuery 1.8.3
+        specialEasing: {}, // cannot be null in jQuery 1.8.3
+        alignWithTop: false,
+        offset: 0
     };
 
     /*


### PR DESCRIPTION
We need two features:

Scroll one item of a long list to the top of the browser window - and only to the top of it. I called the option `.alignWithTop` with respect to the native `.scrollIntoView()` and its alignWithTop-argument. The type of `.alignWithTop` is boolean.

The second feature is an option to set some offset to the position to scroll to. I called the option `.offset`. The type of `.offset` is number || integer.

This PR implements both.
